### PR TITLE
Duplicate @Deprecated annotations

### DIFF
--- a/src/main/java/org/tynamo/security/internal/services/impl/LoginContextServiceImpl.java
+++ b/src/main/java/org/tynamo/security/internal/services/impl/LoginContextServiceImpl.java
@@ -58,19 +58,16 @@ public class LoginContextServiceImpl implements LoginContextService {
 	}
 
 	@Override
-	@Deprecated
 	public String getLoginPage() {
 		return loginPage;
 	}
 
 	@Override
-	@Deprecated
 	public String getSuccessPage() {
 		return defaultSuccessPage;
 	}
 
 	@Override
-	@Deprecated
 	public String getUnauthorizedPage() {
 		return unauthorizedPage;
 	}


### PR DESCRIPTION
The getLoginPage(), getSuccessPage() and getUnauthorizedPage() methods of class LoginContextServiceImpl.java all have @Deprecated annotations on them. Same annotation can also be found in the interface being implemented by the said class. I might be wrong, but using this module in a Tapestry 5.4-beta-22 application results in 

<code>[ERROR] ioc.Registry Error invoking constructor public org.tynamo.security.SecurityComponentRequestFilter(org.tynamo.security.internal.services.LoginContextService,org.apache.tapestry5.services.ComponentClassResolver,org.tynamo.security.services.ClassInterceptorsCache): Duplicate annotation for class: interface java.lang.Deprecated: @java.lang.Deprecated()
[ERROR] ioc.Registry Operations trace:
[ERROR] ioc.Registry [ 1] Realizing service ComponentRequestFilter
[ERROR] ioc.Registry [ 2] Instantiating service ComponentRequestFilter implementation via org.tynamo.security.SecurityComponentRequestFilter(LoginContextService, ComponentClassResolver, ClassInterceptorsCache) (at SecurityComponentRequestFilter.java:25) via org.tynamo.security.services.SecurityModule.bind(ServiceBinder) (at SecurityModule.java:71)
[ERROR] ioc.Registry [ 3] Invoking constructor org.tynamo.security.SecurityComponentRequestFilter(LoginContextService, ComponentClassResolver, ClassInterceptorsCache) (at SecurityComponentRequestFilter.java:25) via org.tynamo.security.services.SecurityModule.bind(ServiceBinder) (at SecurityModule.java:71) (for service 'ComponentRequestFilter')
[ERROR] SecurityModule.ComponentRequestFilter Construction of service ComponentRequestFilter failed: Error invoking constructor public org.tynamo.security.SecurityComponentRequestFilter(org.tynamo.security.internal.services.LoginContextService,org.apache.tapestry5.services.ComponentClassResolver,org.tynamo.security.services.ClassInterceptorsCache): Duplicate annotation for class: interface java.lang.Deprecated: @java.lang.Deprecated()
org.apache.tapestry5.ioc.internal.OperationException: Error invoking constructor public org.tynamo.security.SecurityComponentRequestFilter(org.tynamo.security.internal.services.LoginContextService,org.apache.tapestry5.services.ComponentClassResolver,org.tynamo.security.services.ClassInterceptorsCache): Duplicate annotation for class: interface java.lang.Deprecated: @java.lang.Deprecated()
	at org.apache.tapestry5.ioc.internal.OperationTrackerImpl.logAndRethrow(OperationTrackerImpl.java:184)
	at org.apache.tapestry5.ioc.internal.OperationTrackerImpl.invoke(OperationTrackerImpl.java:90)
	at org.apache.tapestry5.ioc.internal.PerThreadOperationTracker.invoke(PerThreadOperationTracker.java:72)
	at org.apache.tapestry5.ioc.internal.RegistryImpl.invoke(RegistryImpl.java:1258)
	at org.apache.tapestry5.ioc.internal.util.ConstructionPlan.createObject(ConstructionPlan.java:61)
	at org.apache.tapestry5.ioc.internal.ConstructorServiceCreator.createObject(ConstructorServiceCreator.java:62)
	at org.apache.tapestry5.ioc.internal.OperationTrackingObjectCreator$1.invoke(OperationTrackingObjectCreator.java:47)
	at org.apache.tapestry5.ioc.internal.OperationTrackerImpl.invoke(OperationTrackerImpl.java:82)
	at org.apache.tapestry5.ioc.internal.PerThreadOperationTracker.invoke(PerThreadOperationTracker.java:72)
	at org.apache.tapestry5.ioc.internal.RegistryImpl.invoke(RegistryImpl.java:1258)
	at org.apache.tapestry5.ioc.internal.OperationTrackingObjectCreator.createObject(OperationTrackingObjectCreator.java:51)
	at org.apache.tapestry5.ioc.internal.SingletonServiceLifecycle.createService(SingletonServiceLifecycle.java:30)
	at org.apache.tapestry5.ioc.internal.LifecycleWrappedServiceCreator.createObject(LifecycleWrappedServiceCreator.java:47)
	at org.apache.tapestry5.ioc.internal.AdvisorStackBuilder.createObject(AdvisorStackBuilder.java:64)
	at org.apache.tapestry5.ioc.internal.InterceptorStackBuilder.createObject(InterceptorStackBuilder.java:55)
	at org.apache.tapestry5.ioc.internal.RecursiveServiceCreationCheckWrapper.createObject(RecursiveServiceCreationCheckWrapper.java:61)
	at org.apache.tapestry5.ioc.internal.OperationTrackingObjectCreator$1.invoke(OperationTrackingObjectCreator.java:47)
	at org.apache.tapestry5.ioc.internal.OperationTrackerImpl.invoke(OperationTrackerImpl.java:82)
	at org.apache.tapestry5.ioc.internal.PerThreadOperationTracker.invoke(PerThreadOperationTracker.java:72)
	at org.apache.tapestry5.ioc.internal.RegistryImpl.invoke(RegistryImpl.java:1258)
	at org.apache.tapestry5.ioc.internal.OperationTrackingObjectCreator.createObject(OperationTrackingObjectCreator.java:51)
	at org.apache.tapestry5.ioc.internal.services.JustInTimeObjectCreator.obtainObjectFromCreator(JustInTimeObjectCreator.java:67)
	at org.apache.tapestry5.ioc.internal.services.JustInTimeObjectCreator.createObject(JustInTimeObjectCreator.java:55)
	at $ComponentRequestFilter_18d88a69d385.delegate(Unknown Source)
	at $ComponentRequestFilter_18d88a69d385.handlePageRender(Unknown Source)
	at $ComponentRequestHandler_18d88a69d388.handlePageRender(Unknown Source)
	at $ComponentRequestHandler_18d88a69d362.handlePageRender(Unknown Source)
	at org.apache.tapestry5.internal.services.PageRenderDispatcher.dispatch(PageRenderDispatcher.java:52)
	at $Dispatcher_18d88a69d363.dispatch(Unknown Source)
	at $Dispatcher_18d88a69d35c.dispatch(Unknown Source)
	at org.apache.tapestry5.modules.TapestryModule$RequestHandlerTerminator.service(TapestryModule.java:304)
	at org.apache.tapestry5.internal.services.RequestErrorFilter.service(RequestErrorFilter.java:26)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at org.apache.tapestry5.modules.TapestryModule$3.service(TapestryModule.java:854)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at org.apache.tapestry5.modules.TapestryModule$2.service(TapestryModule.java:844)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at org.apache.tapestry5.internal.services.StaticFilesFilter.service(StaticFilesFilter.java:89)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at com.agile.payroll.upay.services.AppModule$2.service(AppModule.java:147)
	at $RequestFilter_18d88a69d358.service(Unknown Source)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at org.apache.tapestry5.internal.services.CheckForUpdatesFilter$2.invoke(CheckForUpdatesFilter.java:105)
	at org.apache.tapestry5.internal.services.CheckForUpdatesFilter$2.invoke(CheckForUpdatesFilter.java:95)
	at org.apache.tapestry5.ioc.internal.util.ConcurrentBarrier.withRead(ConcurrentBarrier.java:85)
	at org.apache.tapestry5.internal.services.CheckForUpdatesFilter.service(CheckForUpdatesFilter.java:119)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at $RequestHandler_18d88a69d31e.service(Unknown Source)
	at org.apache.tapestry5.modules.TapestryModule$HttpServletRequestHandlerTerminator.service(TapestryModule.java:255)
	at org.tynamo.security.services.impl.SecurityConfiguration$1.call(SecurityConfiguration.java:56)
	at org.tynamo.security.services.impl.SecurityConfiguration$1.call(SecurityConfiguration.java:54)
	at org.apache.shiro.subject.support.SubjectCallable.doCall(SubjectCallable.java:90)
	at org.apache.shiro.subject.support.SubjectCallable.call(SubjectCallable.java:83)
	at org.apache.shiro.subject.support.DelegatingSubject.execute(DelegatingSubject.java:383)
	at org.tynamo.security.services.impl.SecurityConfiguration.service(SecurityConfiguration.java:54)
	at $HttpServletRequestFilter_18d88a69d31d.service(Unknown Source)
	at $HttpServletRequestHandler_18d88a69d320.service(Unknown Source)
	at org.apache.tapestry5.upload.internal.services.MultipartServletRequestFilter.service(MultipartServletRequestFilter.java:45)
	at $HttpServletRequestHandler_18d88a69d320.service(Unknown Source)
	at org.apache.tapestry5.internal.gzip.GZipFilter.service(GZipFilter.java:59)
	at $HttpServletRequestHandler_18d88a69d320.service(Unknown Source)
	at org.apache.tapestry5.internal.services.IgnoredPathsFilter.service(IgnoredPathsFilter.java:62)
	at $HttpServletRequestFilter_18d88a69d31a.service(Unknown Source)
	at $HttpServletRequestHandler_18d88a69d320.service(Unknown Source)
	at org.apache.tapestry5.modules.TapestryModule$1.service(TapestryModule.java:804)
	at $HttpServletRequestHandler_18d88a69d320.service(Unknown Source)
	at $HttpServletRequestHandler_18d88a69d319.service(Unknown Source)
	at org.apache.tapestry5.TapestryFilter.doFilter(TapestryFilter.java:166)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:585)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:577)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:223)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:215)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:110)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:497)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.RuntimeException: Error invoking constructor public org.tynamo.security.SecurityComponentRequestFilter(org.tynamo.security.internal.services.LoginContextService,org.apache.tapestry5.services.ComponentClassResolver,org.tynamo.security.services.ClassInterceptorsCache): Duplicate annotation for class: interface java.lang.Deprecated: @java.lang.Deprecated()
	at org.apache.tapestry5.ioc.internal.util.ConstructorInvoker.invoke(ConstructorInvoker.java:59)
	at org.apache.tapestry5.ioc.internal.util.LoggingInvokableWrapper.invoke(LoggingInvokableWrapper.java:43)
	at org.apache.tapestry5.ioc.internal.OperationTrackerImpl.invoke(OperationTrackerImpl.java:82)
	... 86 more
Caused by: java.lang.annotation.AnnotationFormatError: Duplicate annotation for class: interface java.lang.Deprecated: @java.lang.Deprecated()
	at sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:125)
	at sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:72)
	at java.lang.reflect.Executable.declaredAnnotations(Executable.java:546)
	at java.lang.reflect.Executable.getAnnotation(Executable.java:520)
	at java.lang.reflect.Method.getAnnotation(Method.java:607)
	at org.apache.tapestry5.internal.plastic.AbstractMethodInvocation.getAnnotation(AbstractMethodInvocation.java:114)
	at org.apache.tapestry5.internal.plastic.AbstractMethodInvocation.hasAnnotation(AbstractMethodInvocation.java:108)
	at org.apache.tapestry5.internal.jpa.CommitAfterMethodAdvice.advise(CommitAfterMethodAdvice.java:39)
	at org.apache.tapestry5.internal.plastic.AbstractMethodInvocation.proceed(AbstractMethodInvocation.java:92)
	at $LoginContextService_18d88a69d331.getLoginPage(Unknown Source)
	at $LoginContextService_18d88a69d309.getLoginPage(Unknown Source)
	at org.tynamo.security.SecurityComponentRequestFilter.<init>(SecurityComponentRequestFilter.java:30)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:408)
	at org.apache.tapestry5.ioc.internal.util.ConstructorInvoker.invoke(ConstructorInvoker.java:50)
	... 88 more
[ERROR] TapestryModule.RequestExceptionHandler Processing of request failed with uncaught exception: java.lang.RuntimeException: Exception constructing service 'ComponentRequestFilter': Error invoking constructor public org.tynamo.security.SecurityComponentRequestFilter(org.tynamo.security.internal.services.LoginContextService,org.apache.tapestry5.services.ComponentClassResolver,org.tynamo.security.services.ClassInterceptorsCache): Duplicate annotation for class: interface java.lang.Deprecated: @java.lang.Deprecated()
java.lang.RuntimeException: Exception constructing service 'ComponentRequestFilter': Error invoking constructor public org.tynamo.security.SecurityComponentRequestFilter(org.tynamo.security.internal.services.LoginContextService,org.apache.tapestry5.services.ComponentClassResolver,org.tynamo.security.services.ClassInterceptorsCache): Duplicate annotation for class: interface java.lang.Deprecated: @java.lang.Deprecated()
	at org.apache.tapestry5.ioc.internal.services.JustInTimeObjectCreator.obtainObjectFromCreator(JustInTimeObjectCreator.java:76)
	at org.apache.tapestry5.ioc.internal.services.JustInTimeObjectCreator.createObject(JustInTimeObjectCreator.java:55)
	at $ComponentRequestFilter_18d88a69d385.delegate(Unknown Source)
	at $ComponentRequestFilter_18d88a69d385.handlePageRender(Unknown Source)
	at $ComponentRequestHandler_18d88a69d388.handlePageRender(Unknown Source)
	at $ComponentRequestHandler_18d88a69d362.handlePageRender(Unknown Source)
	at org.apache.tapestry5.internal.services.PageRenderDispatcher.dispatch(PageRenderDispatcher.java:52)
	at $Dispatcher_18d88a69d363.dispatch(Unknown Source)
	at $Dispatcher_18d88a69d35c.dispatch(Unknown Source)
	at org.apache.tapestry5.modules.TapestryModule$RequestHandlerTerminator.service(TapestryModule.java:304)
	at org.apache.tapestry5.internal.services.RequestErrorFilter.service(RequestErrorFilter.java:26)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at org.apache.tapestry5.modules.TapestryModule$3.service(TapestryModule.java:854)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at org.apache.tapestry5.modules.TapestryModule$2.service(TapestryModule.java:844)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at org.apache.tapestry5.internal.services.StaticFilesFilter.service(StaticFilesFilter.java:89)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at com.agile.payroll.upay.services.AppModule$2.service(AppModule.java:147)
	at $RequestFilter_18d88a69d358.service(Unknown Source)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at org.apache.tapestry5.internal.services.CheckForUpdatesFilter$2.invoke(CheckForUpdatesFilter.java:105)
	at org.apache.tapestry5.internal.services.CheckForUpdatesFilter$2.invoke(CheckForUpdatesFilter.java:95)
	at org.apache.tapestry5.ioc.internal.util.ConcurrentBarrier.withRead(ConcurrentBarrier.java:85)
	at org.apache.tapestry5.internal.services.CheckForUpdatesFilter.service(CheckForUpdatesFilter.java:119)
	at $RequestHandler_18d88a69d35d.service(Unknown Source)
	at $RequestHandler_18d88a69d31e.service(Unknown Source)
	at org.apache.tapestry5.modules.TapestryModule$HttpServletRequestHandlerTerminator.service(TapestryModule.java:255)
	at org.tynamo.security.services.impl.SecurityConfiguration$1.call(SecurityConfiguration.java:56)
	at org.tynamo.security.services.impl.SecurityConfiguration$1.call(SecurityConfiguration.java:54)
	at org.apache.shiro.subject.support.SubjectCallable.doCall(SubjectCallable.java:90)
	at org.apache.shiro.subject.support.SubjectCallable.call(SubjectCallable.java:83)
	at org.apache.shiro.subject.support.DelegatingSubject.execute(DelegatingSubject.java:383)
	at org.tynamo.security.services.impl.SecurityConfiguration.service(SecurityConfiguration.java:54)
	at $HttpServletRequestFilter_18d88a69d31d.service(Unknown Source)
	at $HttpServletRequestHandler_18d88a69d320.service(Unknown Source)
	at org.apache.tapestry5.upload.internal.services.MultipartServletRequestFilter.service(MultipartServletRequestFilter.java:45)
	at $HttpServletRequestHandler_18d88a69d320.service(Unknown Source)
	at org.apache.tapestry5.internal.gzip.GZipFilter.service(GZipFilter.java:59)
	at $HttpServletRequestHandler_18d88a69d320.service(Unknown Source)
	at org.apache.tapestry5.internal.services.IgnoredPathsFilter.service(IgnoredPathsFilter.java:62)
	at $HttpServletRequestFilter_18d88a69d31a.service(Unknown Source)
	at $HttpServletRequestHandler_18d88a69d320.service(Unknown Source)
	at org.apache.tapestry5.modules.TapestryModule$1.service(TapestryModule.java:804)
	at $HttpServletRequestHandler_18d88a69d320.service(Unknown Source)
	at $HttpServletRequestHandler_18d88a69d319.service(Unknown Source)
	at org.apache.tapestry5.TapestryFilter.doFilter(TapestryFilter.java:166)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:585)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:577)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:223)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:215)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:110)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:497)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.tapestry5.ioc.internal.OperationException: Error invoking constructor public org.tynamo.security.SecurityComponentRequestFilter(org.tynamo.security.internal.services.LoginContextService,org.apache.tapestry5.services.ComponentClassResolver,org.tynamo.security.services.ClassInterceptorsCache): Duplicate annotation for class: interface java.lang.Deprecated: @java.lang.Deprecated()
	at org.apache.tapestry5.ioc.internal.OperationTrackerImpl.logAndRethrow(OperationTrackerImpl.java:184)
	at org.apache.tapestry5.ioc.internal.OperationTrackerImpl.invoke(OperationTrackerImpl.java:90)
	at org.apache.tapestry5.ioc.internal.PerThreadOperationTracker.invoke(PerThreadOperationTracker.java:72)
	at org.apache.tapestry5.ioc.internal.RegistryImpl.invoke(RegistryImpl.java:1258)
	at org.apache.tapestry5.ioc.internal.util.ConstructionPlan.createObject(ConstructionPlan.java:61)
	at org.apache.tapestry5.ioc.internal.ConstructorServiceCreator.createObject(ConstructorServiceCreator.java:62)
	at org.apache.tapestry5.ioc.internal.OperationTrackingObjectCreator$1.invoke(OperationTrackingObjectCreator.java:47)
	at org.apache.tapestry5.ioc.internal.OperationTrackerImpl.invoke(OperationTrackerImpl.java:82)
	at org.apache.tapestry5.ioc.internal.PerThreadOperationTracker.invoke(PerThreadOperationTracker.java:72)
	at org.apache.tapestry5.ioc.internal.RegistryImpl.invoke(RegistryImpl.java:1258)
	at org.apache.tapestry5.ioc.internal.OperationTrackingObjectCreator.createObject(OperationTrackingObjectCreator.java:51)
	at org.apache.tapestry5.ioc.internal.SingletonServiceLifecycle.createService(SingletonServiceLifecycle.java:30)
	at org.apache.tapestry5.ioc.internal.LifecycleWrappedServiceCreator.createObject(LifecycleWrappedServiceCreator.java:47)
	at org.apache.tapestry5.ioc.internal.AdvisorStackBuilder.createObject(AdvisorStackBuilder.java:64)
	at org.apache.tapestry5.ioc.internal.InterceptorStackBuilder.createObject(InterceptorStackBuilder.java:55)
	at org.apache.tapestry5.ioc.internal.RecursiveServiceCreationCheckWrapper.createObject(RecursiveServiceCreationCheckWrapper.java:61)
	at org.apache.tapestry5.ioc.internal.OperationTrackingObjectCreator$1.invoke(OperationTrackingObjectCreator.java:47)
	at org.apache.tapestry5.ioc.internal.OperationTrackerImpl.invoke(OperationTrackerImpl.java:82)
	at org.apache.tapestry5.ioc.internal.PerThreadOperationTracker.invoke(PerThreadOperationTracker.java:72)
	at org.apache.tapestry5.ioc.internal.RegistryImpl.invoke(RegistryImpl.java:1258)
	at org.apache.tapestry5.ioc.internal.OperationTrackingObjectCreator.createObject(OperationTrackingObjectCreator.java:51)
	at org.apache.tapestry5.ioc.internal.services.JustInTimeObjectCreator.obtainObjectFromCreator(JustInTimeObjectCreator.java:67)
	... 66 more
Caused by: java.lang.RuntimeException: Error invoking constructor public org.tynamo.security.SecurityComponentRequestFilter(org.tynamo.security.internal.services.LoginContextService,org.apache.tapestry5.services.ComponentClassResolver,org.tynamo.security.services.ClassInterceptorsCache): Duplicate annotation for class: interface java.lang.Deprecated: @java.lang.Deprecated()
	at org.apache.tapestry5.ioc.internal.util.ConstructorInvoker.invoke(ConstructorInvoker.java:59)
	at org.apache.tapestry5.ioc.internal.util.LoggingInvokableWrapper.invoke(LoggingInvokableWrapper.java:43)
	at org.apache.tapestry5.ioc.internal.OperationTrackerImpl.invoke(OperationTrackerImpl.java:82)
	... 86 more
Caused by: java.lang.annotation.AnnotationFormatError: Duplicate annotation for class: interface java.lang.Deprecated: @java.lang.Deprecated()
	at sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:125)
	at sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:72)
	at java.lang.reflect.Executable.declaredAnnotations(Executable.java:546)
	at java.lang.reflect.Executable.getAnnotation(Executable.java:520)
	at java.lang.reflect.Method.getAnnotation(Method.java:607)
	at org.apache.tapestry5.internal.plastic.AbstractMethodInvocation.getAnnotation(AbstractMethodInvocation.java:114)
	at org.apache.tapestry5.internal.plastic.AbstractMethodInvocation.hasAnnotation(AbstractMethodInvocation.java:108)
	at org.apache.tapestry5.internal.jpa.CommitAfterMethodAdvice.advise(CommitAfterMethodAdvice.java:39)
	at org.apache.tapestry5.internal.plastic.AbstractMethodInvocation.proceed(AbstractMethodInvocation.java:92)
	at $LoginContextService_18d88a69d331.getLoginPage(Unknown Source)
	at $LoginContextService_18d88a69d309.getLoginPage(Unknown Source)
	at org.tynamo.security.SecurityComponentRequestFilter.<init>(SecurityComponentRequestFilter.java:30)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:408)
	at org.apache.tapestry5.ioc.internal.util.ConstructorInvoker.invoke(ConstructorInvoker.java:50)
	... 88 more
[WARN] TapestryModule.ExceptionReporter Wrote exception report to file:/home/seeraj/dev/server/jetty-distribution-9.2.9.v20150224/build/exceptions/2015-03-11/17/13/exception-20150311-171351-267.0.txt

Process finished with exit code 137
Disconnected from server</code>