### PR TITLE
update to jetty 9.2.10.v20150310 and update to tapestry 5.4-beta-31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	</parent>
 
 	<properties>
-		<tapestry-release-version>5.4-beta-22</tapestry-release-version>
+		<tapestry-release-version>5.4-beta-31</tapestry-release-version>
 	</properties>
 
 	<!-- Developers section inherited from the parent pom -->
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.0.3</version>
+			<version>1.1.3</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- slightly annoyingly, we need to use the jetty originated servlet-api because the jars are signed -->
@@ -159,7 +159,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.2.4.v20141103</version>
+				<version>9.2.10.v20150310</version>
 				<configuration>
 					<contextPath>/</contextPath>
 					<useTestClasspath>true</useTestClasspath>


### PR DESCRIPTION
http://dev.eclipse.org/mhonarc/lists/jetty-announce/msg00076.html

http://dev.eclipse.org/mhonarc/lists/jetty-announce/msg00074.html Critical Security Release of Jetty 9.2.9.v20150224 
Jetty 9.2.3 through 9.2.8