### PR TITLE
Contribution methods are used to contribute to wrong services

### DIFF
--- a/src/main/java/org/tynamo/security/Security.java
+++ b/src/main/java/org/tynamo/security/Security.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@Target({PARAMETER, FIELD, METHOD})
+@Target({PARAMETER, FIELD, METHOD, TYPE})
 @Retention(RUNTIME)
 @Documented
 public @interface Security {

--- a/src/main/java/org/tynamo/security/services/SecurityModule.java
+++ b/src/main/java/org/tynamo/security/services/SecurityModule.java
@@ -25,7 +25,6 @@ import org.apache.tapestry5.ioc.ServiceBinder;
 import org.apache.tapestry5.ioc.annotations.Contribute;
 import org.apache.tapestry5.ioc.annotations.InjectService;
 import org.apache.tapestry5.ioc.annotations.Local;
-import org.apache.tapestry5.ioc.annotations.Marker;
 import org.apache.tapestry5.ioc.annotations.Match;
 import org.apache.tapestry5.ioc.annotations.Order;
 import org.apache.tapestry5.ioc.annotations.Symbol;
@@ -64,7 +63,7 @@ import org.tynamo.shiro.extension.authz.aop.SecurityInterceptor;
  * The main entry point for Security integration.
  *
  */
-@Marker(Security.class)
+@Security
 public class SecurityModule
 {
 	private static final String PATH_PREFIX = "security";
@@ -77,7 +76,7 @@ public class SecurityModule
 		// because Shiro tests if the object is an instanceof LogoutAware to call logout handlers
 		binder.bind(ModularRealmAuthenticator.class);
 		binder.bind(SubjectFactory.class, DefaultWebSubjectFactory.class);
-		binder.bind(HttpServletRequestFilter.class, SecurityConfiguration.class).withId("SecurityConfiguration");
+		binder.bind(HttpServletRequestFilter.class, SecurityConfiguration.class).withId("SecurityConfiguration").withMarker(Security.class);
 		binder.bind(ClassInterceptorsCache.class, ClassInterceptorsCacheImpl.class);
 		binder.bind(SecurityService.class, SecurityServiceImpl.class);
 		binder.bind(SecurityFilterChainFactory.class, SecurityFilterChainFactoryImpl.class);
@@ -258,7 +257,7 @@ public class SecurityModule
 	}
 
 	@Contribute(HttpServletRequestFilter.class)
-	@Marker(Security.class)
+	@Security
 	public static void defaultSecurity(Configuration<SecurityFilterChain> configuration,
 		SecurityFilterChainFactory factory) {
 		configuration.add(factory.createChain("/modules.gz/**").add(factory.anon()).build());

--- a/src/test/java/org/tynamo/security/testapp/services/AFilter.java
+++ b/src/test/java/org/tynamo/security/testapp/services/AFilter.java
@@ -1,0 +1,19 @@
+package org.tynamo.security.testapp.services;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.tapestry5.ioc.annotations.UsesMappedConfiguration;
+import org.apache.tapestry5.services.HttpServletRequestFilter;
+import org.apache.tapestry5.services.HttpServletRequestHandler;
+@UsesMappedConfiguration(key = String.class, value = String.class)
+public class AFilter implements HttpServletRequestFilter {
+  @Override
+  public boolean service(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse, final HttpServletRequestHandler httpServletRequestHandler) throws IOException {
+    return httpServletRequestHandler.service(httpServletRequest, httpServletResponse);
+  }
+
+  public AFilter(Map<String, String> config) {
+  }
+}

--- a/src/test/java/org/tynamo/security/testapp/services/AppModule.java
+++ b/src/test/java/org/tynamo/security/testapp/services/AppModule.java
@@ -29,7 +29,6 @@ import org.apache.tapestry5.ioc.OrderedConfiguration;
 import org.apache.tapestry5.ioc.ServiceBinder;
 import org.apache.tapestry5.ioc.annotations.Contribute;
 import org.apache.tapestry5.ioc.annotations.Local;
-import org.apache.tapestry5.ioc.annotations.Marker;
 import org.apache.tapestry5.ioc.annotations.Startup;
 import org.apache.tapestry5.ioc.annotations.SubModule;
 import org.apache.tapestry5.services.HttpServletRequestFilter;
@@ -162,7 +161,7 @@ public class AppModule
 	}
 
 	@Contribute(HttpServletRequestFilter.class)
-	@Marker(Security.class)
+	@Security
 	public static void setupSecurity(Configuration<SecurityFilterChain> configuration,
 			SecurityFilterChainFactory factory, WebSecurityManager securityManager) {
 //		if (securityManager instanceof DefaultSecurityManager) {

--- a/src/test/java/org/tynamo/security/testapp/services/AppModule.java
+++ b/src/test/java/org/tynamo/security/testapp/services/AppModule.java
@@ -53,7 +53,7 @@ import org.tynamo.shiro.extension.realm.text.ExtendedPropertiesRealm;
  * This module is automatically included as part of the Tapestry IoC Registry, it's a good place to
  * configure and extend Tapestry, or to place your own service definitions.
  */
-@SubModule({ SecurityModule.class, TestModule.class })
+@SubModule({ SecurityModule.class, TestModule.class, FalseContributionModule.class })
 public class AppModule
 {
 

--- a/src/test/java/org/tynamo/security/testapp/services/FalseContributionModule.java
+++ b/src/test/java/org/tynamo/security/testapp/services/FalseContributionModule.java
@@ -1,0 +1,17 @@
+package org.tynamo.security.testapp.services;
+
+import org.apache.tapestry5.ioc.OrderedConfiguration;
+import org.apache.tapestry5.ioc.ServiceBinder;
+import org.apache.tapestry5.services.HttpServletRequestFilter;
+
+public class FalseContributionModule {
+
+  public static void bind(ServiceBinder binder){
+    binder.bind(AFilter.class, AFilter.class);
+  }
+  public static void contributeHttpServletRequestHandler(
+          OrderedConfiguration<HttpServletRequestFilter> configuration, AFilter aFilter)
+  {
+    configuration.add("aFilter",aFilter);
+  }
+}


### PR DESCRIPTION
Contribution methods in SecurityModule and AppModule are not restricted to only contribute to SecurityConfiguration. Rather they are trying contribute to all implementations of HttpServletRequestFilter. 

Checkout https://github.com/tynamo/tapestry-security/commit/83c9de9f51c1862c8a4e99d71f4b2bbd70d6d609 and run tests to reproduce.

Bug occurred while i was trying to use tapestry-security in combination with https://github.com/uklance/tapestry-atmosphere which also has a implementation of HttpServletRequestFilter but uses a MappedConfiguration which finally leads to a error like this:

`Error invoking service contribution method org.tynamo.security.services.SecurityModule.defaultSecurity(Configuration, SecurityFilterChainFactory): Service 'AFilter' is configured using org.apache.tapestry5.ioc.MappedConfiguration, not org.apache.tapestry5.ioc.Configuration.`